### PR TITLE
Chore: Create a workflow to build and push to `gh-pages`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,54 @@
+name: Build and push to gh-pages branch
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  upload-to-gh-pages:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build
+        env:
+          VITE_API_KEY: ${{ secrets.VITE_API_KEY }}
+        run: npm run build
+
+
+      - name: Clean gh-pages branch and push build
+        run: |
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+
+          git fetch origin
+          git switch gh-pages || git checkout -b gh-pages
+
+          # Clean the gh-pages branch (remove all files except dist/ and .git)
+          git ls-tree --name-only HEAD | grep -vE '(^dist$|^.git$)' | xargs git rm -rf
+
+          mv dist/* ./
+          rm -rf dist/
+
+          # Ensure asset paths are relative in the entry file
+          sed -i 's|/assets/|assets/|g' index.html
+
+          COMMIT_HASH=$(git log origin/main -1 --pretty=%h)
+          COMMIT_MSG="Latest build from commit $COMMIT_HASH"
+
+          git add .
+          git commit -m "$COMMIT_MSG"
+
+          git push -f origin gh-pages
+

--- a/script/setup
+++ b/script/setup
@@ -15,3 +15,4 @@ curl --location "https://getpantry.cloud/apiv1/pantry/$pantry_id/basket/users" \
 --header "Content-Type: application/json" \
 --data "$seed_data"
 
+npm i

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  build: {
+    target: 'esnext',
+    base: './',
+  },
+});
+


### PR DESCRIPTION
# Description

This PR makes sure our JavaScript files in Production can use the Environment Variable for the production Pantry ID.

Before, the default GitHub Pages deployment action didn’t handle environment variables properly in the minified files. 
Now, with Vite, we’ve set it up so that the build process replaces those variable imports with the actual values.

From now on, every time there’s a change pushed to `main`, this workflow will kick off, build the site, and deploy it to the `gh-pages` branch with the correct environment variables included.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How to Test

Since a push to `main` is the trigger, this is something we'll only be able to test when this PR is merged.
With that said, I tested it when listening to a different event. 

1. Access https://patdel0.github.io/SAGP/ and confirm you're able to add names to the list.
2. Confirm the workflow runs were successful:
- https://github.com/patdel0/SAGP/actions/runs/12082114222/job/33692544370
- https://github.com/patdel0/SAGP/actions/runs/12082118004

# Checklist:

- [X] I have performed a self-review of my code
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
